### PR TITLE
4 swagger dokümantasyonu

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.5.0</version>
+			<version>2.8.9</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.5</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath/> 
 	</parent>
 	<groupId>com.tefasfundapi</groupId>
 	<artifactId>tefasFundAPI</artifactId>

--- a/src/main/java/com/tefasfundapi/tefasFundAPI/client/HistoryClient.java
+++ b/src/main/java/com/tefasfundapi/tefasFundAPI/client/HistoryClient.java
@@ -39,8 +39,7 @@ public class HistoryClient {
         try (Playwright pw = Playwright.create()) {
             log.debug("fetchHistoryJson started for fundCode={}, start={}, end={}", fundCode, start, end);
             // Launch browser with configuration
-            BrowserType.LaunchOptions launchOptions = PlaywrightHelper.createLaunchOptions(config)
-                    .setHeadless(false);
+            BrowserType.LaunchOptions launchOptions = PlaywrightHelper.createLaunchOptions(config);
             try (Browser browser = pw.chromium().launch(launchOptions)) {
                 BrowserContext ctx = browser.newContext(PlaywrightHelper.createContextOptions(config));
                 try {

--- a/src/main/java/com/tefasfundapi/tefasFundAPI/config/OpenApiConfig.java
+++ b/src/main/java/com/tefasfundapi/tefasFundAPI/config/OpenApiConfig.java
@@ -1,0 +1,51 @@
+package com.tefasfundapi.tefasFundAPI.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI tefasFundApiOpenAPI() {
+        Server localServer = new Server();
+        localServer.setUrl("http://localhost:8080");
+        localServer.setDescription("Local development server");
+
+        Contact contact = new Contact();
+        contact.setName("TEFAS Fund API");
+        contact.setUrl("https://github.com/KULLANICI_ADI/tefas-fund-api");
+
+        License license = new License();
+        license.setName("Apache 2.0");
+        license.setUrl("https://www.apache.org/licenses/LICENSE-2.0.html");
+
+        Info info = new Info()
+                .title("TEFAS Fund Data API")
+                .version("0.0.1-SNAPSHOT")
+                .description("""
+                        Türkiye'deki yatırım fonları hakkında veri sağlayan RESTful API Proxy.
+                        TEFAS (Takasbank Elektronik Fon Alım Satım Platformu) web sitesinden
+                        Playwright kullanarak veri çeker ve düzenlenmiş, kullanıma hazır JSON formatında sunar.
+                        
+                        ## Özellikler
+                        - **Fon Bilgileri**: Fon koduna göre detaylı fon bilgileri (getiri oranları, fon türü, vb.)
+                        - **NAV Geçmişi**: Fonların tarihsel NAV (Net Aktif Değer) verileri
+                        - **Fon Performansı**: Tarih aralığına göre fon getirileri
+                        - **Field Filtering**: İhtiyacınız olan alanları seçerek response boyutunu optimize edin
+                        """)
+                .contact(contact)
+                .license(license);
+
+        return new OpenAPI()
+                .info(info)
+                .servers(List.of(localServer));
+    }
+}

--- a/src/main/java/com/tefasfundapi/tefasFundAPI/controller/FundController.java
+++ b/src/main/java/com/tefasfundapi/tefasFundAPI/controller/FundController.java
@@ -6,6 +6,15 @@ import com.tefasfundapi.tefasFundAPI.exception.InvalidDateRangeException;
 import com.tefasfundapi.tefasFundAPI.filter.FieldFilter;
 import com.tefasfundapi.tefasFundAPI.service.TefasService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -22,6 +31,7 @@ import java.time.LocalDate;
 @RestController
 @RequestMapping("/v1/funds")
 @Validated
+@Tag(name = "Funds", description = "Fon bilgileri ve performans verilerini getiren endpoint'ler")
 public class FundController {
 
     private final TefasService tefasService;
@@ -30,24 +40,39 @@ public class FundController {
         this.tefasService = tefasService;
     }
 
-    // GET /v1/funds/{code}?fields=code,name,...
+    @Operation(summary = "Fon detayı getir", description = "Belirli bir fonun detaylı bilgilerini getirir. Fon kodu ile sorgulama yapılır. "
+            +
+            "İsteğe bağlı olarak sadece belirli alanları döndürmek için 'fields' parametresi kullanılabilir.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Fon bilgileri başarıyla getirildi", content = @Content(mediaType = "application/json", schema = @Schema(implementation = FundDto.class))),
+            @ApiResponse(responseCode = "404", description = "Fon bulunamadı", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "Geçersiz parametre", content = @Content(mediaType = "application/json"))
+    })
     @GetMapping("/{code}")
     public ResponseEntity<?> getFund(
-            @PathVariable @NotBlank(message = "Fund code cannot be blank") String code,
-            @RequestParam(required = false, name = "fields") String fieldsCsv) {
+            @Parameter(description = "Fon kodu (örn: AAK, AOY)", required = true, example = "AAK") @PathVariable @NotBlank(message = "Fund code cannot be blank") String code,
+            @Parameter(description = "Döndürülecek alanlar (virgülle ayrılmış). Örn: fundCode,fundName,getiri1A", example = "fundCode,fundName,getiri1A") @RequestParam(required = false, name = "fields") String fieldsCsv) {
         List<String> fields = FieldFilter.parse(fieldsCsv);
         FundDto fund = tefasService.getFund(code.trim(), fields)
                 .orElseThrow(() -> new FundNotFoundException(code));
         return ResponseEntity.ok(FieldFilter.apply(fund, fields));
     }
 
-    // FundController.java
+    @Operation(summary = "Fon performansı getir", description = "Belirli bir fonun seçilen tarih aralığındaki performans getirilerini getirir. "
+            +
+            "Tarih aralığına göre fon getirilerini (BindComparisonFundReturns) döndürür. " +
+            "Sayfalama desteği vardır (page, size parametreleri).")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Fon performans verileri başarıyla getirildi", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "404", description = "Fon bulunamadı", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "Geçersiz tarih aralığı veya parametre", content = @Content(mediaType = "application/json"))
+    })
     @GetMapping("/{code}/performance")
     public ResponseEntity<?> getPerformance(
-            @PathVariable @NotBlank(message = "Fund code cannot be blank") String code,
-            @RequestParam @NotNull(message = "Start date is required") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
-            @RequestParam @NotNull(message = "End date is required") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end,
-            @PageableDefault(size = 20) Pageable pageable) {
+            @Parameter(description = "Fon kodu", required = true, example = "AAK") @PathVariable @NotBlank(message = "Fund code cannot be blank") String code,
+            @Parameter(description = "Başlangıç tarihi (YYYY-MM-DD formatında)", required = true, example = "2024-01-01") @RequestParam @NotNull(message = "Start date is required") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @Parameter(description = "Bitiş tarihi (YYYY-MM-DD formatında)", required = true, example = "2024-03-01") @RequestParam @NotNull(message = "End date is required") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end,
+            @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
 
         if (start.isAfter(end)) {
             throw new InvalidDateRangeException("start date must be <= end date");

--- a/src/main/java/com/tefasfundapi/tefasFundAPI/controller/FundController.java
+++ b/src/main/java/com/tefasfundapi/tefasFundAPI/controller/FundController.java
@@ -1,6 +1,8 @@
 package com.tefasfundapi.tefasFundAPI.controller;
 
 import com.tefasfundapi.tefasFundAPI.dto.FundDto;
+import com.tefasfundapi.tefasFundAPI.dto.FundPerformanceDto;
+import com.tefasfundapi.tefasFundAPI.dto.PagedResponse;
 import com.tefasfundapi.tefasFundAPI.exception.FundNotFoundException;
 import com.tefasfundapi.tefasFundAPI.exception.InvalidDateRangeException;
 import com.tefasfundapi.tefasFundAPI.filter.FieldFilter;
@@ -62,13 +64,8 @@ public class FundController {
             +
             "Tarih aralığına göre fon getirilerini (BindComparisonFundReturns) döndürür. " +
             "Sayfalama desteği vardır (page, size parametreleri).")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Fon performans verileri başarıyla getirildi", content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "404", description = "Fon bulunamadı", content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "400", description = "Geçersiz tarih aralığı veya parametre", content = @Content(mediaType = "application/json"))
-    })
     @GetMapping("/{code}/performance")
-    public ResponseEntity<?> getPerformance(
+    public ResponseEntity<PagedResponse<FundPerformanceDto>> getPerformance(
             @Parameter(description = "Fon kodu", required = true, example = "AAK") @PathVariable @NotBlank(message = "Fund code cannot be blank") String code,
             @Parameter(description = "Başlangıç tarihi (YYYY-MM-DD formatında)", required = true, example = "2024-01-01") @RequestParam @NotNull(message = "Start date is required") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
             @Parameter(description = "Bitiş tarihi (YYYY-MM-DD formatında)", required = true, example = "2024-03-01") @RequestParam @NotNull(message = "End date is required") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end,

--- a/src/main/java/com/tefasfundapi/tefasFundAPI/controller/HistoryController.java
+++ b/src/main/java/com/tefasfundapi/tefasFundAPI/controller/HistoryController.java
@@ -4,6 +4,14 @@ import com.tefasfundapi.tefasFundAPI.exception.FundNotFoundException;
 import com.tefasfundapi.tefasFundAPI.exception.InvalidDateRangeException;
 import com.tefasfundapi.tefasFundAPI.service.TefasService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -19,6 +27,7 @@ import java.time.LocalDate;
 @RestController
 @RequestMapping("/v1/funds")
 @Validated
+@Tag(name = "Fund History", description = "Fonların tarihsel NAV (Net Aktif Değer) verilerini getiren endpoint'ler")
 public class HistoryController {
 
     private final TefasService tefasService;
@@ -27,16 +36,21 @@ public class HistoryController {
         this.tefasService = tefasService;
     }
 
-    /**
-     * Tek fonun tarihsel fiyat/NAV akışı
-     * GET /v1/funds/{code}/nav?start=YYYY-MM-DD&end=YYYY-MM-DD&page=0&size=20
-     */
+    @Operation(summary = "Fon NAV geçmişi getir", description = "Fonun belirli bir tarih aralığındaki NAV (Net Aktif Değer) geçmişini getirir. "
+            +
+            "Her gün için fiyat, çıkışta dolaşan pay sayısı, toplam değer ve yatırımcı sayısı bilgilerini içerir. " +
+            "Sayfalama desteği vardır (page, size parametreleri).")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "NAV geçmişi başarıyla getirildi", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "404", description = "Fon bulunamadı", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "Geçersiz tarih aralığı veya parametre", content = @Content(mediaType = "application/json"))
+    })
     @GetMapping("/{code}/nav")
     public ResponseEntity<?> getNav(
-            @PathVariable @NotBlank(message = "Fund code cannot be blank") String code,
-            @RequestParam @NotNull(message = "Start date is required") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
-            @RequestParam @NotNull(message = "End date is required") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end,
-            @PageableDefault(size = 20) Pageable pageable) {
+            @Parameter(description = "Fon kodu", required = true, example = "AAK") @PathVariable @NotBlank(message = "Fund code cannot be blank") String code,
+            @Parameter(description = "Başlangıç tarihi (YYYY-MM-DD formatında)", required = true, example = "2024-01-01") @RequestParam @NotNull(message = "Start date is required") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @Parameter(description = "Bitiş tarihi (YYYY-MM-DD formatında)", required = true, example = "2024-01-31") @RequestParam @NotNull(message = "End date is required") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end,
+            @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
 
         if (start.isAfter(end)) {
             throw new InvalidDateRangeException("start date must be <= end date");

--- a/src/main/java/com/tefasfundapi/tefasFundAPI/controller/HistoryController.java
+++ b/src/main/java/com/tefasfundapi/tefasFundAPI/controller/HistoryController.java
@@ -3,12 +3,11 @@ package com.tefasfundapi.tefasFundAPI.controller;
 import com.tefasfundapi.tefasFundAPI.exception.FundNotFoundException;
 import com.tefasfundapi.tefasFundAPI.exception.InvalidDateRangeException;
 import com.tefasfundapi.tefasFundAPI.service.TefasService;
+import com.tefasfundapi.tefasFundAPI.dto.PagedResponse;
+import com.tefasfundapi.tefasFundAPI.dto.PriceRowDto;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springdoc.core.annotations.ParameterObject;
 
@@ -40,13 +39,8 @@ public class HistoryController {
             +
             "Her gün için fiyat, çıkışta dolaşan pay sayısı, toplam değer ve yatırımcı sayısı bilgilerini içerir. " +
             "Sayfalama desteği vardır (page, size parametreleri).")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "NAV geçmişi başarıyla getirildi", content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "404", description = "Fon bulunamadı", content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "400", description = "Geçersiz tarih aralığı veya parametre", content = @Content(mediaType = "application/json"))
-    })
     @GetMapping("/{code}/nav")
-    public ResponseEntity<?> getNav(
+    public ResponseEntity<PagedResponse<PriceRowDto>> getNav(
             @Parameter(description = "Fon kodu", required = true, example = "AAK") @PathVariable @NotBlank(message = "Fund code cannot be blank") String code,
             @Parameter(description = "Başlangıç tarihi (YYYY-MM-DD formatında)", required = true, example = "2024-01-01") @RequestParam @NotNull(message = "Start date is required") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
             @Parameter(description = "Bitiş tarihi (YYYY-MM-DD formatında)", required = true, example = "2024-01-31") @RequestParam @NotNull(message = "End date is required") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end,

--- a/src/main/java/com/tefasfundapi/tefasFundAPI/controller/MetaController.java
+++ b/src/main/java/com/tefasfundapi/tefasFundAPI/controller/MetaController.java
@@ -1,14 +1,31 @@
 package com.tefasfundapi.tefasFundAPI.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.*;
 
 @RestController
 @RequestMapping("/v1/meta")
+@Tag(name = "Meta", description = "API metadata ve cache bilgilerini getiren endpoint'ler")
 public class MetaController {
 
-    // GET /v1/meta/last-sync
+    @Operation(
+            summary = "Son senkronizasyon bilgileri",
+            description = "API'nin son veri senkronizasyon bilgilerini getirir. " +
+                    "Her kaynak için son kontrol zamanı, durum ve ETag bilgilerini içerir."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Metadata başarıyla getirildi",
+                    content = @Content(mediaType = "application/json")
+            )
+    })
     @GetMapping("/last-sync")
     public Map<String, Object> getLastSync() {
         Map<String, Object> resources = new HashMap<>();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces OpenAPI/Swagger documentation and improves endpoint contracts.
> 
> - Adds `OpenApiConfig` with API metadata, server info, contact, and license
> - Annotates `FundController`, `HistoryController`, and `MetaController` with `@Tag`, `@Operation`, parameter/response schemas, and examples
> - Changes return types to typed pagination: `getPerformance` -> `ResponseEntity<PagedResponse<FundPerformanceDto>>`, `getNav` -> `ResponseEntity<PagedResponse<PriceRowDto>>`
> - Upgrades dependency `springdoc-openapi-starter-webmvc-ui` to `2.8.9` in `pom.xml`
> - Tweaks Playwright client by removing `.setHeadless(false)` in `HistoryClient` to use config defaults
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88def085a97353bb45fc736e950f3605313feafe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->